### PR TITLE
Changes to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,14 +175,14 @@ class ExampleClassTests: XCTestCase {
         XCTAssertFalse(mock.invoked(function: "foo"))
     }
 
-    func testFooCalledWithBlankByDefault() {
+    func testFooWasCalled() {
         mock.foo(description: "updated")
         mock.foo(description: "updated")
 
         XCTAssertTrue(mock.invoked(function: "foo", with: ["updated"]))
     }
 
-    func testFooCalledThreeTimes() {
+    func testFooWasCalledThreeTimes() {
         mock.foo(description: "thrice")
         mock.foo(description: "thrice")
         mock.foo(description: "thrice")


### PR DESCRIPTION
This makes a few changes to the README.md

The most salient change is that there is a discussion of making mocks extend or conform to the protocol of the object that is being mocked. Additionally, in most of the examples, the class that is being mocked is included in the example. 

The largest downside that I can see in these changes is that it increases the length of the README significantly. Additionally, some of the explanations are wordy. 

If there are any changes that would make this make more sense, please let me know. On the other hand, if this change is rejected I will not be offended.